### PR TITLE
Continue translation of launch tutorials for rolling

### DIFF
--- a/source/Tutorials/Intermediate/Launch/Launch-Main.rst
+++ b/source/Tutorials/Intermediate/Launch/Launch-Main.rst
@@ -8,7 +8,7 @@
 Launch
 ======
 
-ROS 2 Launch files allow you to start up and configure a number of executables containing ROS 2 nodes simultaneously.
+Los ficheros de ROS 2 launch te permiten iniciar y configurar varios ejecutables que contienen nodos de ROS 2 simultáneamente.
 
 .. toctree::
    :hidden:
@@ -19,27 +19,27 @@ ROS 2 Launch files allow you to start up and configure a number of executables c
    Using-Event-Handlers
    Using-ROS2-Launch-For-Large-Projects
 
-#. :doc:`Creating a launch file <./Creating-Launch-Files>`.
+#. :doc:`Crear un fichero de launch<./Creating-Launch-Files>`.
 
-   Learn how to create a launch file that will start up nodes and their configurations all at once.
+   Aprende como crear un fichero de launch que iniciará nodos y sus configuraciones de una sola vez.
 
-#. :doc:`Launching and monitoring multiple nodes <./Launch-system>`.
+#. :doc:`Launching y monitorizado de multiples nodos <./Launch-system>`.
 
-   Get a more advanced overview of how launch files work.
+   Obtén una visión general mas avanzada de como funcionan los ficheros de launch.
 
-#. :doc:`Using substitutions <./Using-Substitutions>`.
+#. :doc:`Utilizar substituciones <./Using-Substitutions>`.
 
-   Use substitutions to provide more flexibility when describing reusable launch files.
+   Usa substituciones para proveer mayor flexibilidad cuando describas ficheros launch reusables.
 
-#. :doc:`Using event handlers <./Using-Event-Handlers>`.
+#. :doc:`Utilizar controladores de evento <./Using-Event-Handlers>`.
 
-   Use event handlers to monitor the state of processes or to define a complex set of rules that can be used to dynamically modify the launch file.
+   Usa controladores de evento para monitorizar el estado de los procesos o para definir un conjunto complejo de reglas que pueden ser utilizados para modificar de forma dinámica los ficheros de launch.
 
-#. :doc:`Managing large projects <./Using-ROS2-Launch-For-Large-Projects>`.
+#. :doc:`Gestión de proyectos grandes <./Using-ROS2-Launch-For-Large-Projects>`.
 
-   Structure launch files for large projects so they may be reused as much as possible in different situations.
-   See usage examples of different launch tools like parameters, YAML files, remappings, namespaces, default arguments, and RViz configs.
+   Estructura ficheros de launch para proyectos grandes para poder reutilizarlos tanto como sea posible en diferentes situaciones.
+   Ve ejemplos de uso de diferentes herramientas de launch como parámetros, ficheros YAML, remappings, namespaces, argumentos por defecto, y configuraciones de RViz.
 
 .. note::
 
-   If you are coming from ROS 1, you can use the :doc:`ROS Launch Migration guide <../../../How-To-Guides/Launch-files-migration-guide>` to help you migrate your launch files to ROS 2.
+   Si tu vienes de ROS 1, puedes ver el :doc:`ROS Launch guía de migración <../../../How-To-Guides/Launch-files-migration-guide>` para ayudarte a migrar tus ficheros launch a ROS 2.

--- a/source/Tutorials/Intermediate/Launch/Launch-system.rst
+++ b/source/Tutorials/Intermediate/Launch/Launch-system.rst
@@ -4,39 +4,39 @@
   Tutorials/Launch-Files/Launch-system
   Tutorials/Launch/Launch-system
 
-Integrating launch files into ROS 2 packages
-============================================
+Integrar ficheros de launch a paquetes de ROS 2
+===============================================
 
-**Goal:** Add a launch file to a ROS 2 package
+**Objetivo:** Añadir un fichero de launch a un paquete de ROS 2
 
-**Tutorial level:** Intermediate
+**Nivel del tutorial:** Intermedio
 
-**Time:** 10 minutes
+**Tiempo:** 10 minutos
 
-.. contents:: Contents
+.. contents:: Contenidos
    :depth: 2
    :local:
 
-Prerequisites
+Prerequisitos
 -------------
 
-You should have gone through the tutorial on how to :doc:`create a ROS 2 package <../../Beginner-Client-Libraries/Creating-Your-First-ROS2-Package>`.
+Deberías de haber repasado el tutorial sobre como :doc:`Crear un paquete de ROS 2<../../Beginner-Client-Libraries/Creating-Your-First-ROS2-Package>`.
 
-As always, don’t forget to source ROS 2 in :doc:`every new terminal you open <../../Beginner-CLI-Tools/Configuring-ROS2-Environment>`.
+Como siempre, no te olvides de sincronizar las fuentes de ROS 2 en :doc:`cada terminal que abra <../../Beginner-CLI-Tools/Configuring-ROS2-Environment>`.
 
-Background
-----------
+Antecedentes
+------------
 
-In the :doc:`previous tutorial <Creating-Launch-Files>`, we saw how to write a standalone launch file.
-This tutorial will show how to add a launch file to an existing package, and the conventions typically used.
+En el :doc:`tutorial anterior <Creating-Launch-Files>`, vimos como escribir un fichero de launch independiente.
+Este tutorial mostrará como añadir un fichero de launch a un paquete existente, y las convenciones que se suelen utilizar.
 
-Tasks
------
+Tareas
+------
 
-1 Create a package
+1 Crear un paquete
 ^^^^^^^^^^^^^^^^^^
 
-Create a workspace for the package to live in:
+Crea un workspace donde vivirá el paquete:
 
 .. tabs::
 
@@ -75,17 +75,17 @@ Create a workspace for the package to live in:
 
       ros2 pkg create cpp_launch_example --build-type ament_cmake
 
-2 Creating the structure to hold launch files
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+2 Crear la estructura para mantener ficheros de launch
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-By convention, all launch files for a package are stored in the ``launch`` directory inside of the package.
-Make sure to create a ``launch`` directory at the top-level of the package you created above.
+Por convención, todos los ficheros de launch para un paquete son almacenados en la carpeta ``launch`` dentro del paquete.
+Asegúrate de crear la carpeta ``launch`` en el nivel mas alto del paquete que creaste arriba.
 
 .. tabs::
 
   .. group-tab:: Python package
 
-    For Python packages, the directory containing your package should look like this:
+    Para los paquetes de Python, la carpeta que contiene tu paquete debe verse como esto:
 
     .. code-block:: console
 
@@ -99,9 +99,9 @@ Make sure to create a ``launch`` directory at the top-level of the package you c
           setup.py
           test/
 
-    In order for colcon to find the launch files, we need to inform Python's setup tools of our launch files using the ``data_files`` parameter of ``setup``.
+    Para que colcon pueda encontrar los ficheros de launch, necesitamos informar a las herramientas de setup de Pyton acerca de nuestros ficheros de launch usando el parámetro ``data_files`` de ``setup``.
 
-    Inside our ``setup.py`` file:
+    Dentro de nuestro fichero ``setup.py``:
 
     .. code-block:: python
 
@@ -114,15 +114,15 @@ Make sure to create a ``launch`` directory at the top-level of the package you c
       setup(
           # Other parameters ...
           data_files=[
-              # ... Other data files
-              # Include all launch files.
+              # ... Otros ficheros de datos
+              # Incluye todos los ficheros de launch.
               (os.path.join('share', package_name), glob('launch/*launch.[pxy][yma]*'))
           ]
       )
 
   .. group-tab:: C++ package
 
-    For C++ packages, we will only be adjusting the ``CMakeLists.txt`` file by adding:
+    Para los paquetes de C++, solo ajustaremos el fichero de ``CMakeLists.txt`` añadiendo:
 
     .. code-block:: cmake
 
@@ -132,21 +132,21 @@ Make sure to create a ``launch`` directory at the top-level of the package you c
         DESTINATION share/${PROJECT_NAME}/
       )
 
-    to the end of the file (but before ``ament_package()``).
+    al final del fichero (pero antes de ``ament_package()``).
 
 
-3 Writing the launch file
-^^^^^^^^^^^^^^^^^^^^^^^^^
+3 Escribir el fichero de launch
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. tabs::
 
   .. group-tab:: Python launch file
 
-    Inside your ``launch`` directory, create a new launch file called ``my_script_launch.py``.
-    ``_launch.py`` is recommended, but not required, as the file suffix for Python launch files.
-    However, the launch file name needs to end with ``launch.py`` to be recognized and autocompleted by ``ros2 launch``.
+    Dentro de tu carpeta ``launch``, crea un nuevo fichero de launch llamado ``my_script_launch.py``.
+    Se recomienda``_launch.py``, aunque no es obligatorio, como sufijo para ficheros de launch de Python.
+    Sin embargo, el nombre del fichero de launch necesita terminar con ``launch.py`` para ser reconocido y autocompletado por ``ros2 launch``.
 
-    Your launch file should define the ``generate_launch_description()`` function which returns a ``launch.LaunchDescription()`` to be used by the ``ros2 launch`` verb.
+    Tu fichero de launch debe definir la función ``generate_launch_description()``, la cual regresa un ``launch.LaunchDescription()`` que es usado por el verbo ``ros2 launch``.
 
     .. code-block:: python
 
@@ -163,8 +163,8 @@ Make sure to create a ``launch`` directory at the top-level of the package you c
 
   .. group-tab:: XML launch file
 
-    Inside your ``launch`` directory, create a new launch file called ``my_script_launch.xml``.
-    ``_launch.xml`` is recommended, but not required, as the file suffix for XML launch files.
+    Dentro de tu carpeta ``launch``, crea un nuevo fichero de launch llamado ``my_script_launch.xml``.
+    Se recomienda``_launch.xml``, aunque no es obligatorio, como sufijo para ficheros de launch de XML.
 
     .. code-block:: xml
 
@@ -174,8 +174,8 @@ Make sure to create a ``launch`` directory at the top-level of the package you c
 
   .. group-tab:: YAML launch file
 
-    Inside your ``launch`` directory, create a new launch file called ``my_script_launch.yaml``.
-    ``_launch.yaml`` is recommended, but not required, as the file suffix for YAML launch files.
+    Dentro de tu carpeta ``launch``, crea un nuevo fichero de launch llamado ``my_script_launch.yaml``.
+    Se recomienda``_launch.xml``, aunque no es obligatorio, como sufijo para ficheros de launch de YAML.
 
     .. code-block:: yaml
 
@@ -187,16 +187,16 @@ Make sure to create a ``launch`` directory at the top-level of the package you c
           name: "talker"
 
 
-4 Building and running the launch file
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+4 Compilar y ejecutar el fichero de launch
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Go to the top-level of the workspace, and build it:
+Ve al nivel mas alto del workspace, y compílalo:
 
 .. code-block:: console
 
   colcon build
 
-After the ``colcon build`` has been successful and you've sourced the workspace, you should be able to run the launch file as follows:
+Después de que ``colcon build`` haya sido exitoso y que hayas ejecutado source en el workspace, deberías de ser capas de ejecutar el fichero de launch como sigue:
 
 .. tabs::
 
@@ -245,10 +245,11 @@ After the ``colcon build`` has been successful and you've sourced the workspace,
           ros2 launch cpp_launch_example my_script_launch.yaml
 
 
-Documentation
+Documentación
 -------------
 
 `The launch documentation <https://github.com/ros2/launch/blob/{REPOS_FILE_BRANCH}/launch/doc/source/architecture.rst>`__ provides more details on concepts that are also used in ``launch_ros``.
+`La documentación de launch <https://github.com/ros2/launch/blob/{REPOS_FILE_BRANCH}/launch/doc/source/architecture.rst>`__ provee mas destalles sobre los conceptos que también son usados en ``launch_ros``.
 
-Additional documentation/examples of launch capabilities are forthcoming.
-See the source code (https://github.com/ros2/launch and https://github.com/ros2/launch_ros) in the meantime.
+Documentación y ejemplos adicionales sobre las capacidades de launch están por venir.
+De momento ve el código fuente (https://github.com/ros2/launch y https://github.com/ros2/launch_ros).

--- a/source/Tutorials/Intermediate/Launch/Using-Event-Handlers.rst
+++ b/source/Tutorials/Intermediate/Launch/Using-Event-Handlers.rst
@@ -3,45 +3,45 @@
     Tutorials/Launch-Files/Using-Event-Handlers
     Tutorials/Launch/Using-Event-Handlers
 
-Using event handlers
-====================
+Utilizar controladores de eventos
+=================================
 
-**Goal:** Learn about event handlers in ROS 2 launch files
+**Objetivo:** Aprender acerca de los controladores de eventos en ficheros de launch de ROS 2
 
-**Tutorial level:** Intermediate
+**Nivel del tutorial:** Intermedio
 
-**Time:** 15 minutes
+**Tiempo:** 15 minutos
 
-.. contents:: Table of Contents
+.. contents:: Tabla de Contenido
    :depth: 2
    :local:
 
-Background
-----------
+Antecedentes
+------------
 
-Launch in ROS 2 is a system that executes and manages user-defined processes.
-It is responsible for monitoring the state of processes it launched, as well as reporting and reacting to changes in the state of those processes.
-These changes are called events and can be handled by registering an event handler with the launch system.
-Event handlers can be registered for specific events and can be useful for monitoring the state of processes.
-Additionally, they can be used to define a complex set of rules which can be used to dynamically modify the launch file.
+Launch en ROS 2 es un sistema que ejecuta y maneja procesos definidos por un usuario.
+Es responsable de monitorizar el estado de los procesos launched, así como de reportar y reaccionar a los cambios en el estado de esos procesos.
+Estos cambios son llamados eventos y pueden ser controlados al registrar un controlador de eventos con el sistema de launch.
+Controladores de eventos pueden ser registrados para eventos específicos y puede ser útiles para monitorizar el estado de procesos.
+Adicionalmente, ellos puede ser usados para definir un conjunto complejo de reglas, las cuales pueden ser usadas para modificar dinámicamente el fichero de launch.
 
-This tutorial shows usage examples of event handlers in ROS 2 launch files.
+Este tutorial muestra ejemplos de uso de controladores de eventos en ficheros de launch de ROS 2.
 
-Prerequisites
+Prerequisitos
 -------------
 
-This tutorial uses the :doc:`turtlesim <../../Beginner-CLI-Tools/Introducing-Turtlesim/Introducing-Turtlesim>` package.
-This tutorial also assumes you have :doc:`created a new package <../../Beginner-Client-Libraries/Creating-Your-First-ROS2-Package>` of build type ``ament_python`` called ``launch_tutorial``.
+Este tutorial usa el paquete de :doc:`turtlesim <../../Beginner-CLI-Tools/Introducing-Turtlesim/Introducing-Turtlesim>`.
+Este tutorial también asume que tu has :doc:`creado un nuevo paquete <../../Beginner-Client-Libraries/Creating-Your-First-ROS2-Package>` de tipo de compilación ``ament_python`` llamado ``launch_tutorial``.
 
-This tutorial extends the code shown in the :doc:`Using substitutions in launch files <./Using-Substitutions>` tutorial.
+Este tutorial extiende el código mostrado en el tutorial :doc:`Utilizar substituciones en ficheros de launch <./Using-Substitutions>`.
 
-Using event handlers
---------------------
+Utilizar controladores de eventos
+---------------------------------
 
-1 Event handlers example launch file
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+1 Ejemplo de fichero de launch con controladores de evento
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Create a new file called ``example_event_handlers.launch.py`` file in the ``launch`` folder of the ``launch_tutorial`` package.
+Crea un nuevo fichero llamado ``example_event_handlers.launch.py`` en la carpeta ``launch`` del paquete ``launch_tutorial``.
 
 .. code-block:: python
 
@@ -180,10 +180,10 @@ Create a new file called ``example_event_handlers.launch.py`` file in the ``laun
             ),
         ])
 
-``RegisterEventHandler`` actions for the ``OnProcessStart``, ``OnProcessIO``, ``OnExecutionComplete``, ``OnProcessExit``, and ``OnShutdown`` events were defined in the launch description.
+Las acciones ``RegisterEventHandler`` para los eventos ``OnProcessStart``, ``OnProcessIO``, ``OnExecutionComplete``, ``OnProcessExit`` y ``OnShutdown`` fueron definidas en la descripción del launch.
 
-The ``OnProcessStart`` event handler is used to register a callback function that is executed when the turtlesim node starts.
-It logs a message to the console and executes the ``spawn_turtle`` action when the turtlesim node starts.
+El controlador de evento ``OnProcessStart`` es usado para registrar una función callback que es ejecutada cuando el nodo turtlesim empieza.
+Registra un mensaje en la consola y ejecuta la acción ``spawn_turtle`` cuando el nodo turtlesim empieza.
 
 .. code-block:: python
 
@@ -197,8 +197,8 @@ It logs a message to the console and executes the ``spawn_turtle`` action when t
         )
     ),
 
-The ``OnProcessIO`` event handler is used to register a callback function that is executed when the ``spawn_turtle`` action writes to its standard output.
-It logs the result of the spawn request.
+El controlador de evento ``OnProcessIO`` es usado para registrar una función callback que es ejecutada cuando la acción ``spawn_turtle`` escribe su salida estándar.
+Registra el resultado de la solicitud de despliegue.
 
 .. code-block:: python
 
@@ -212,8 +212,8 @@ It logs the result of the spawn request.
         )
     ),
 
-The ``OnExecutionComplete`` event handler is used to register a callback function that is executed when the ``spawn_turtle`` action completes.
-It logs a message to the console and executes the ``change_background_r`` and ``change_background_r_conditioned`` actions when the spawn action completes.
+El controlador de evento ``OnExecutionComplete`` es usado para registrar una función callback que se ejecuta cuando la acción ``spawn_turtle`` es completada.
+Registra un mensaje en la consola y ejecuta las acciones ``change_background_r`` y ``change_background_r_conditioned`` cuando la acción de despliegue es completada.
 
 .. code-block:: python
 
@@ -231,9 +231,9 @@ It logs a message to the console and executes the ``change_background_r`` and ``
         )
     ),
 
-The ``OnProcessExit`` event handler is used to register a callback function that is executed when the turtlesim node exits.
-It logs a message to the console and executes the ``EmitEvent`` action to emit a ``Shutdown`` event when the turtlesim node exits.
-It means that the launch process will shutdown when the turtlesim window is closed.
+El controlador de evento ``OnProcessExit`` es usado para registrar una función callback que se ejecuta cuando el nodo turtlesim termina.
+Registra un mensaje en la consola y ejecuta la acción ``EmitEvent`` para emitir un evento ``Shutdown`` cuando el nodo turtlesim termina.
+Esto significa que el proceso launch terminará cuando la ventana de turtlesim se cierre.
 
 .. code-block:: python
 
@@ -249,9 +249,9 @@ It means that the launch process will shutdown when the turtlesim window is clos
         )
     ),
 
-Finally, the ``OnShutdown`` event handler is used to register a callback function that is executed when the launch file is asked to shutdown.
-It logs a message to the console why the launch file is asked to shutdown.
-It logs the message with a reason for shutdown like the closure of turtlesim window or ``ctrl-c`` signal made by the user.
+Finalmente, el controlador de evento ``OnShutdown`` es usado para registrar una función callback que se ejecuta cuando se solicita la terminación del fichero de launch.
+Registra un mensaje en la consola sobre el porque se solicitó la terminación del fichero de launch.
+Registra el mensaje con una razón para la terminación como el cierre de la ventana de turtlesim o la señal ``ctrl-c`` hecha por el usuario.
 
 .. code-block:: python
 
@@ -264,50 +264,51 @@ It logs the message with a reason for shutdown like the closure of turtlesim win
         )
     ),
 
-Build the package
------------------
+Compila el paquete
+------------------
 
-Go to the root of the workspace, and build the package:
+Ve a la raíz del workspace, y compila el paquete.
 
 .. code-block:: console
 
   colcon build
 
-Also remember to source the workspace after building.
+También recuerda ejecutar source al workspace después de compilar.
 
-Launching example
------------------
+Ejemplo de launching
+--------------------
 
-Now you can launch the ``example_event_handlers.launch.py`` file using the ``ros2 launch`` command.
+Ahora puedes hacer launch al fichero ``example_event_handlers.launch.py`` usando el comando ``ros2 launch``.
 
 .. code-block:: console
 
     ros2 launch launch_tutorial example_event_handlers.launch.py turtlesim_ns:='turtlesim3' use_provided_red:='True' new_background_r:=200
 
-This will do the following:
+Esto hará lo siguiente:
 
-#. Start a turtlesim node with a blue background
-#. Spawn the second turtle
+#. Empieza un nodo turtlesim con el fondo azul
+#. Despliega la segunda tortuga
 #. Change the color to purple
-#. Change the color to pink after two seconds if the provided ``background_r`` argument is ``200`` and ``use_provided_red`` argument is ``True``
-#. Shutdown the launch file when the turtlesim window is closed
+#. Cambia el color a morado.
+#. Cambia el color a rosa después de dos segundos si el argumento ``background_r`` es ``200`` y el argumento ``use_provided_red`` es ``True``
+#. Termina el fichero de launch cuando la ventana de turtlesim se cierra
 
-Additionally, it will log messages to the console when:
+Adicionalmente, registrará mensajes en la consola cuando:
 
-#. The turtlesim node starts
-#. The spawn action is executed
-#. The ``change_background_r`` action is executed
-#. The ``change_background_r_conditioned`` action is executed
-#. The turtlesim node exits
-#. The launch process is asked to shutdown.
+#. El nodo turtlesim empieza
+#. La acción de despliegue se ejecuta
+#. La acción ``change_background_r`` se ejecuta
+#. La acción ``change_background_r_conditioned`` se ejecuta
+#. El nodo turtlesim termina
+#. Se solicita el terminado al proceso de launch
 
-Documentation
+Documentación
 -------------
 
-`The launch documentation <https://github.com/ros2/launch/blob/{REPOS_FILE_BRANCH}/launch/doc/source/architecture.rst>`_ provides detailed information about available event handlers.
+`La documentación de launch <https://github.com/ros2/launch/blob/{REPOS_FILE_BRANCH}/launch/doc/source/architecture.rst>`_ provee información detallada acerca de los controladores de eventos disponibles.
 
-Summary
+Resumen
 -------
 
-In this tutorial, you learned about using event handlers in launch files.
-You learned about their syntax and usage examples to define a complex set of rules to dynamically modify launch files.
+En este tutorial, aprendiste acerca de la utilización de controladores de eventos en los ficheros de launch.
+Aprendiste acerca de su sintaxis y ejemplos de uso para definir un conjunto complejo de reglas que modifican dinámicamente ficheros de launch.


### PR DESCRIPTION
Translated:
- [Launch-Main.rst](https://github.com/ROS-Spanish-Users-Group/ros2_documentation/blob/rolling/source/Tutorials/Intermediate/Launch/Launch-Main.rst)
- [Launch-system.rst](https://github.com/ROS-Spanish-Users-Group/ros2_documentation/blob/rolling/source/Tutorials/Intermediate/Launch/Launch-system.rst)
- [Using-Event-Handlers.rst](https://github.com/ROS-Spanish-Users-Group/ros2_documentation/blob/rolling/source/Tutorials/Intermediate/Launch/Using-Event-Handlers.rst)